### PR TITLE
Parse socks5 username and password from proxy_url

### DIFF
--- a/urllib3/contrib/socks.py
+++ b/urllib3/contrib/socks.py
@@ -161,6 +161,11 @@ class SOCKSProxyManager(PoolManager):
             )
 
         self.proxy_url = proxy_url
+        
+        if username is None and password is None and parsed.auth is not None:
+            split = parsed.auth.split(':')
+            if len(split) == 2:
+                username, password = split
 
         socks_options = {
             'socks_version': socks_version,


### PR DESCRIPTION
Parse this information like in https://github.com/urllib3/urllib3/pull/1363
After this change all works fine with socks5 containing username and password